### PR TITLE
세벌식 3-2014 이름 변경

### DIFF
--- a/hangul/hangulinputcontext.c
+++ b/hangul/hangulinputcontext.c
@@ -412,6 +412,14 @@ static const HangulKeyboard hangul_keyboard_3_2012_loose = {
     &hangul_combination_3_loose
 };
 
+static const HangulKeyboard hangul_keyboard_3_2014 = {
+    HANGUL_KEYBOARD_TYPE_JASO,
+    "3-2014",
+    N_("Sebeolsik Moachigi 2014"),
+    (ucschar*)hangul_keyboard_table_3_2014,
+    &hangul_combination_3_2014
+};
+
 static const HangulKeyboard* hangul_keyboards[] = {
     &hangul_keyboard_2,
     &hangul_keyboard_2y,
@@ -429,6 +437,7 @@ static const HangulKeyboard* hangul_keyboards[] = {
     &hangul_keyboard_3_2011_loose,
     &hangul_keyboard_3_2012,
     &hangul_keyboard_3_2012_loose,
+    &hangul_keyboard_3_2014,
 };
 
 

--- a/hangul/hangulkeyboard.h
+++ b/hangul/hangulkeyboard.h
@@ -2464,3 +2464,245 @@ static const ucschar hangul_keyboard_table_3_2012[] = {
     0x0000      /* 0x7F delete                                       */
 };
 
+
+static const ucschar hangul_keyboard_table_3_2014[] = {
+    0x0000,     /* 0x00 null                                         */
+    0x0000,     /* 0x01 start of heading                             */
+    0x0000,     /* 0x02 start of text                                */
+    0x0000,     /* 0x03 end of text                                  */
+    0x0000,     /* 0x04 end of transmission                          */
+    0x0000,     /* 0x05 enquiry                                      */
+    0x0000,     /* 0x06 acknowledge                                  */
+    0x0000,     /* 0x07 bell                                         */
+    0x0000,     /* 0x08 backspace                                    */
+    0x0000,     /* 0x09 character tabulation                         */
+    0x0000,     /* 0x0A line feed (lf)                               */
+    0x0000,     /* 0x0B line tabulation                              */
+    0x0000,     /* 0x0C form feed (ff)                               */
+    0x0000,     /* 0x0D carriage return (cr)                         */
+    0x0000,     /* 0x0E shift out                                    */
+    0x0000,     /* 0x0F shift in                                     */
+    0x0000,     /* 0x10 data link escape                             */
+    0x0000,     /* 0x11 device control one                           */
+    0x0000,     /* 0x12 device control two                           */
+    0x0000,     /* 0x13 device control three                         */
+    0x0000,     /* 0x14 device control four                          */
+    0x0000,     /* 0x15 negative acknowledge                         */
+    0x0000,     /* 0x16 synchronous idle                             */
+    0x0000,     /* 0x17 end of transmission block                    */
+    0x0000,     /* 0x18 cancel                                       */
+    0x0000,     /* 0x19 end of medium                                */
+    0x0000,     /* 0x1A substitute                                   */
+    0x0000,     /* 0x1B escape                                       */
+    0x0000,     /* 0x1C information separator four                   */
+    0x0000,     /* 0x1D information separator three                  */
+    0x0000,     /* 0x1E information separator two                    */
+    0x0000,     /* 0x1F information separator one                    */
+    0x0000,     /* 0x20 space                                        */
+    0x0021,     /* 0x21 exclam:         exclamation mark             */
+    0x0022,     /* 0x22 quotedbl:       quotatioin mark              */
+    0x0023,     /* 0x23 numbersign:     number sign                  */
+    0x0024,     /* 0x24 dollar:         dollar sign                  */
+    0x0025,     /* 0x25 percent:        percent sign                 */
+    0x0026,     /* 0x26 ampersand:      ampersand                    */
+    0x0027,     /* 0x27 apostrophe:     apostrophe                   */
+    0x0028,     /* 0x28 parenleft:      left parenthesis             */
+    0x0029,     /* 0x29 parenright:     right parenthesis            */
+    0x002a,     /* 0x2A asterisk:       asterisk                     */
+    0x002b,     /* 0x2B plus:           plus sign                    */
+    0x002c,     /* 0x2C comma:          comma                        */
+    0x002d,     /* 0x2D minus:          minus sign                   */
+    0x002e,     /* 0x2E period:         period                       */
+    0x002f,     /* 0x2F slash:          slash                        */
+    0x0030,     /* 0x30 0:              0                            */
+    0x11bb,     /* 0x31 1:              jongseong ssangsios          */
+    0x11ae,     /* 0x32 2:              jongseong tikeut             */
+    0x11b8,     /* 0x33 3:              jongseong pieup              */
+    0x116d,     /* 0x34 4:              jungseong yo                 */
+    0x1163,     /* 0x35 5:              jungseong ya                 */
+    0x0036,     /* 0x36 6:              6                            */
+    0x0037,     /* 0x37 7:              7                            */
+    0x0038,     /* 0x38 8:              8                            */
+    0x0039,     /* 0x39 9:              9                            */
+    0x0034,     /* 0x3A colon:          4                            */
+    0x1169,     /* 0x3B semicolon:      jungseong o                  */
+    0x002c,     /* 0x3C less:           comma                        */
+    0x003d,     /* 0x3D equal:          euals sign                   */
+    0x002e,     /* 0x3E greater:        period                       */
+    0x003f,     /* 0x3F question:       question mark                */
+    0x0040,     /* 0x40 at:             commertial at                */
+    0x2606,     /* 0x41 A:              ☆ white star                */
+    0x003b,     /* 0x42 B:              semicolon                    */
+    0x300c,     /* 0x43 C:              「 left corner bracket       */
+    0x25B2,     /* 0x44 D:              ▲ black up-pointing triangle */
+    0x2192,     /* 0x45 E:              → rightwards arrow          */
+    0x00b7,     /* 0x46 F:              middle dot                   */
+    0x003a,     /* 0x47 G:              colon                        */
+    0x0030,     /* 0x48 H:              0                            */
+    0x0037,     /* 0x49 I:              7                            */
+    0x0031,     /* 0x4A J:              1                            */
+    0x0032,     /* 0x4B K:              2                            */
+    0x0033,     /* 0x4C L:              3                            */
+    0x003e,     /* 0x4D M:              greater-than sign            */
+    0x003c,     /* 0x4E N:              less-than sign               */
+    0x0038,     /* 0x4F O:              8                            */
+    0x0039,     /* 0x50 P:              9                            */
+    0x2661,     /* 0x51 Q:              ♡ white heart suit          */
+    0x2194,     /* 0x52 R:              ↔ left right arrow          */
+    0x25bd,     /* 0x53 S:              ▽ white down-pointing triangle */
+    0x203b,     /* 0x54 T:              ※ reference mark            */
+    0x0036,     /* 0x55 U:              6                            */
+    0x300d,     /* 0x56 V:              」 right corner bracket      */
+    0x2190,     /* 0x57 W:              ← leftwards arrow           */
+    0x25ce,     /* 0x58 X:              ◎ bullseye                  */
+    0x0035,     /* 0x59 Y:              5                            */
+    0x25a1,     /* 0x5A Z:              □ white square              */
+    0x005b,     /* 0x5B bracketleft:    left bracket                 */
+    0x005c,     /* 0x5C backslash:      backslash                    */
+    0x005d,     /* 0x5D bracketright:   right bracket                */
+    0x005e,     /* 0x5E asciicircum:    circumflex accent            */
+    0x005f,     /* 0x5F underscore:     underscore                   */
+    0x0060,     /* 0x60 quoteleft:      grave accent                 */
+    0x11bc,     /* 0x61 a:              jongseong ieung              */
+    0x1166,     /* 0x62 b:              jungseong e                  */
+    0x116e,     /* 0x63 c:              jungseong u                  */
+    0x1175,     /* 0x64 d:              jungseong i                  */
+    0x11af,     /* 0x65 e:              jongseong rieul              */
+    0x1161,     /* 0x66 f:              jungseong a                  */
+    0x1173,     /* 0x67 g:              jungseong eu                 */
+    0x1102,     /* 0x68 h:              choseong  nieun              */
+    0x1106,     /* 0x69 i:              choseong  mieum              */
+    0x110b,     /* 0x6A j:              choseong  ieung              */
+    0x1100,     /* 0x6B k:              choseong  kiyeok             */
+    0x110c,     /* 0x6C l:              choseong  cieuc              */
+    0x1112,     /* 0x6D m:              choseong  hieuh              */
+    0x1109,     /* 0x6E n:              choseong  sios               */
+    0x1107,     /* 0x6F o:              choseong  pieup              */
+    0x116e,     /* 0x70 p:              jungseong u                  */
+    0x11c2,     /* 0x71 q:              jongseong hieuh              */
+    0x1165,     /* 0x72 r:              jungseong eo                 */
+    0x11ab,     /* 0x73 s:              jongseong nieun              */
+    0x1167,     /* 0x74 t:              jungseong yeo                */
+    0x1103,     /* 0x75 u:              choseong  tikeut             */
+    0x1169,     /* 0x76 v:              jungseong o                  */
+    0x11ba,     /* 0x77 w:              jongseong sios               */
+    0x11a8,     /* 0x78 x:              jongseong kiyeok             */
+    0x1105,     /* 0x79 y:              choseong  rieul              */
+    0x11b7,     /* 0x7A z:              jongseong mieum              */
+    0x007b,     /* 0x7B braceleft:      left brace                   */
+    0x007c,     /* 0x7C bar:            vertical line(bar)           */
+    0x007d,     /* 0x7D braceright:     right brace                  */
+    0x007e,     /* 0x7E asciitilde:     tilde                        */
+    0x0000      /* 0x7F delete                                       */
+};
+
+static const HangulCombinationItem hangul_combination_table_3_2014[] = {
+  { 0x1100110b, 0x1101 }, /* choseong  kiyeok + ieung   = ssangkiyeok   */
+  { 0x11001112, 0x110f }, /* choseong  kiyeok + hieuh   = khieukh       */
+  { 0x1103110b, 0x1104 }, /* choseong  tikeut + ieung   = ssangtikeut   */
+  { 0x11031112, 0x1110 }, /* choseong  tikeut + hieuh   = thikeuth      */
+  { 0x1106110b, 0x1104 }, /* choseong  mieum  + ieung   = ssangtikeut   */
+  { 0x1107110b, 0x1108 }, /* choseong  pieup  + ieung   = ssangpieup    */
+  { 0x11071112, 0x1111 }, /* choseong  pieup  + hieuh   = phieuph       */
+  { 0x1109110b, 0x110a }, /* choseong  sios   + ieung   = ssangsios     */
+  { 0x11091112, 0x110e }, /* choseong  sios   + hieuh   = chieuch       */
+  { 0x110b1100, 0x1101 }, /* choseong  ieung  + kiyeok  = ssangkiyeok   */
+  { 0x110b1103, 0x1104 }, /* choseong  ieung  + tikeut  = ssangtikeut   */
+  { 0x110b1106, 0x1104 }, /* choseong  ieung  + mieum   = ssangtikeut   */
+  { 0x110b1107, 0x1108 }, /* choseong  ieung  + pieup   = ssangpieup    */
+  { 0x110b1109, 0x110a }, /* choseong  ieung  + sios    = ssangsios     */
+  { 0x110b110c, 0x110d }, /* choseong  ieung  + cieuc   = ssangcieuc    */
+  { 0x110c110b, 0x110d }, /* choseong  cieuc  + ieung   = ssangcieuc    */
+  { 0x110c1112, 0x110e }, /* choseong  cieuc  + hieuh   = chieuch       */
+  { 0x11121100, 0x110f }, /* choseong  hieuh  + kiyeok  = khieukh       */
+  { 0x11121103, 0x1110 }, /* choseong  hieuh  + tikeut  = thikeuth      */
+  { 0x11121107, 0x1111 }, /* choseong  hieuh  + pieup   = phieuph       */
+  { 0x11121109, 0x110e }, /* choseong  hieuh  + sios    = chieuch       */
+  { 0x1112110c, 0x110e }, /* choseong  hieuh  + cieuc   = chieuch       */
+  { 0x11611165, 0x116d }, /* jungseong a      + eo      = yo            */
+  { 0x11611166, 0x1163 }, /* jungseong a      + e       = ya            */
+  { 0x11611169, 0x116a }, /* jungseong a      + o       = wa            */
+  { 0x1161116c, 0x116b }, /* jungseong a      + oe      = wae           */
+  { 0x1161116e, 0x1172 }, /* jungseong a      + u       = yu            */
+  { 0x11611173, 0x119e }, /* jungseong a      + eu      = araea         */
+  { 0x11611175, 0x1162 }, /* jungseong a      + i       = ae            */
+  { 0x11621169, 0x116b }, /* jungseong ae     + o       = wae           */
+  { 0x11631175, 0x1164 }, /* jungseong ya     + i       = yae           */
+  { 0x11651161, 0x116d }, /* jungseong eo     + a       = yo            */
+  { 0x11651167, 0x1164 }, /* jungseong eo     + yeo     = yae           */
+  { 0x1165116e, 0x116f }, /* jungseong eo     + u       = weo           */
+  { 0x11651171, 0x1170 }, /* jungseong eo     + wi      = we            */
+  { 0x11651175, 0x1166 }, /* jungseong eo     + i       = e             */
+  { 0x11661161, 0x1163 }, /* jungseong e      + a       = ya            */
+  { 0x1166116e, 0x1170 }, /* jungseong e      + u       = we            */
+  { 0x11661175, 0x1168 }, /* jungseong e      + i       = ye            */
+  { 0x11671165, 0x1164 }, /* jungseong yeo    + eo      = yae           */
+  { 0x11691161, 0x116a }, /* jungseong o      + a       = wa            */
+  { 0x11691162, 0x116b }, /* jungseong o      + ae      = wae           */
+  { 0x1169116e, 0x116d }, /* jungseong o      + u       = yo            */
+  { 0x11691175, 0x116c }, /* jungseong o      + i       = oe            */
+  { 0x116a1175, 0x116b }, /* jungseong wa     + i       = wae           */
+  { 0x116c1161, 0x116b }, /* jungseong oe     + a       = wae           */
+  { 0x116e1161, 0x1172 }, /* jungseong u      + a       = yu            */
+  { 0x116e1165, 0x116f }, /* jungseong u      + eo      = weo           */
+  { 0x116e1166, 0x1170 }, /* jungseong u      + e       = we            */
+  { 0x116e1169, 0x116d }, /* jungseong u      + o       = yo            */
+  { 0x116e1175, 0x1171 }, /* jungseong u      + i       = wi            */
+  { 0x116f1175, 0x1170 }, /* jungseong weo    + i       = we            */
+  { 0x11711165, 0x1170 }, /* jungseong wi     + eo      = we            */
+  { 0x11731161, 0x119e }, /* jungseong eu     + a       = araea         */
+  { 0x11731175, 0x1174 }, /* jungseong eu     + i       = yi            */
+  { 0x11751161, 0x1162 }, /* jungseong i      + a       = ae            */
+  { 0x11751163, 0x1164 }, /* jungseong i      + ya      = yae           */
+  { 0x11751165, 0x1166 }, /* jungseong i      + eo      = e             */
+  { 0x11751166, 0x1168 }, /* jungseong i      + e       = ye            */
+  { 0x11751169, 0x116c }, /* jungseong i      + o       = oe            */
+  { 0x1175116a, 0x116b }, /* jungseong i      + wa      = wae           */
+  { 0x1175116e, 0x1171 }, /* jungseong i      + u       = wi            */
+  { 0x1175116f, 0x1170 }, /* jungseong i      + weo     = we            */
+  { 0x11751173, 0x1174 }, /* jungseong i      + eu      = yi            */
+  { 0x11a811af, 0x11b0 }, /* jongseong kiyeok + rieul   = rieul-kiyeok  */
+  { 0x11a811b7, 0x11b0 }, /* jongseong kiyeok + mieum   = rieul-kiyeok  */
+  { 0x11a811ba, 0x11aa }, /* jongseong kiyeok + sios    = kiyeok-sois   */
+  { 0x11a811bc, 0x11a9 }, /* jongseong kiyeok + ieung   = ssangekiyeok  */
+  { 0x11a811c2, 0x11bf }, /* jongseong kiyeok + hieuh   = khieukh       */
+  { 0x11ab11af, 0x11ac }, /* jongseong nieun  + rieul   = nieun-cieuc   */
+  { 0x11ab11b7, 0x11ae }, /* jongseong nieun  + mieum   = tikeut        */
+  { 0x11ab11bc, 0x11b8 }, /* jongseong nieun  + ieung   = pieup         */
+  { 0x11ab11c2, 0x11ad }, /* jongseong nieun  + hieuh   = nieun-hieuh   */
+  { 0x11ae11af, 0x11b4 }, /* jongseong tikeut + rieul   = rieul-thieuth */
+  { 0x11ae11b8, 0x11b5 }, /* jongseong tikeut + pieup   = rieul-phieuph */
+  { 0x11ae11c2, 0x11c0 }, /* jongseong tikeut + hieuh   = thikeuth      */
+  { 0x11af11a8, 0x11b0 }, /* jongseong rieul  + kiyeok  = rieul-kiyeok  */
+  { 0x11af11ab, 0x11ac }, /* jongseong rieul  + nieun   = nieun-cieuc   */
+  { 0x11af11ae, 0x11b4 }, /* jongseong rieul  + tikeut  = rieul-thieuth */
+  { 0x11af11b7, 0x11b1 }, /* jongseong rieul  + mieum   = rieul-mieum   */
+  { 0x11af11b8, 0x11b2 }, /* jongseong rieul  + pieup   = rieul-pieup   */
+  { 0x11af11ba, 0x11bd }, /* jongseong rieul  + sios    = cieuc         */
+  { 0x11af11bb, 0x11b3 }, /* jongseong rieul  + ssangsios = rieul-sios    */
+  { 0x11af11bc, 0x11b2 }, /* jongseong rieul  + ieung   = rieul-pieup   */
+  { 0x11af11c2, 0x11b6 }, /* jongseong rieul  + hieuh   = rieul-hieuh   */
+  { 0x11b711a8, 0x11b0 }, /* jongseong mieum  + kiyeok  = rieul-kiyeok  */
+  { 0x11b711ab, 0x11ae }, /* jongseong mieum  + nieun   = tikeut        */
+  { 0x11b711af, 0x11b1 }, /* jongseong mieum  + rieul   = rieul-mieum   */
+  { 0x11b811ae, 0x11b5 }, /* jongseong pieup  + tikeut  = rieul-phieuph */
+  { 0x11b811af, 0x11b2 }, /* jongseong pieup  + rieul   = rieul-pieup   */
+  { 0x11b811ba, 0x11b9 }, /* jongseong pieup  + sios    = pieup-sios    */
+  { 0x11b811c2, 0x11c1 }, /* jongseong pieup  + hieuh   = phieuph       */
+  { 0x11ba11a8, 0x11aa }, /* jongseong sios   + kiyeok  = kiyeok-sois   */
+  { 0x11ba11af, 0x11bd }, /* jongseong sios   + rieul   = cieuc         */
+  { 0x11ba11b8, 0x11b9 }, /* jongseong sios   + pieup   = pieup-sios    */
+  { 0x11ba11bc, 0x11bb }, /* jongseong sios   + ieung   = ssangsios     */
+  { 0x11ba11c2, 0x11be }, /* jongseong sios   + hieuh   = chieuch       */
+  { 0x11bb11af, 0x11b3 }, /* jongseong ssangsios  + rieul = rieul-sios    */
+  { 0x11bc11a8, 0x11a9 }, /* jongseong ieung  + kiyeok  = ssangekiyeok  */
+  { 0x11bc11ab, 0x11b8 }, /* jongseong ieung  + nieun   = pieup         */
+  { 0x11bc11af, 0x11b2 }, /* jongseong ieung  + rieul   = rieul-pieup   */
+  { 0x11bc11ba, 0x11bb }, /* jongseong ieung  + sios    = ssangsios     */
+  { 0x11c211a8, 0x11bf }, /* jongseong hieuh  + kiyeok  = khieukh       */
+  { 0x11c211ab, 0x11ad }, /* jongseong hieuh  + nieun   = nieun-hieuh   */
+  { 0x11c211ae, 0x11c0 }, /* jongseong hieuh  + tikeut  = thikeuth      */
+  { 0x11c211af, 0x11b6 }, /* jongseong hieuh  + rieul   = rieul-hieuh   */
+  { 0x11c211b8, 0x11c1 }, /* jongseong hieuh  + pieup   = phieuph       */
+  { 0x11c211ba, 0x11be }, /* jongseong hieuh  + sios    = chieuch       */
+};

--- a/po/ko.po
+++ b/po/ko.po
@@ -59,3 +59,7 @@ msgstr "세벌식 3-2011"
 #: hangul/hangulinputcontext.c:358
 msgid "Sebeolsik 3-2012"
 msgstr "세벌식 3-2012"
+
+#: hangul/hangulinputcontext.c:418
+msgid "Sebeolsik Moachigi 2014"
+msgstr "세벌식 모아치기 2014"


### PR DESCRIPTION
번거롭게 해 드려서 죄송합니다... '세벌식 사랑 모임' 카페에서 이 자판에 대해 토론을 한 결과, 이 자판의 이름을 바꾸게 되었습니다.  '세벌식 3-2014 통합' 에서 '세벌식 모아치기 2014'로 바꾸게 되어 풀 리퀘스트를 드리게 되었습니다...
