### PR TITLE
Add 2-full and 2y-full for complete map

### DIFF
--- a/data/keyboards/hangul-keyboard-2-full.xml.template
+++ b/data/keyboards/hangul-keyboard-2-full.xml.template
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hangul-keyboard id="2-full" type="jamo">
+
+    <_name>Dubeolsik</_name>
+
+    <map id="0">
+        <item key="0x21" value="0x0021"/>  <!-- ! → !  -->
+        <item key="0x22" value="0x0022"/>  <!-- " → "  -->
+        <item key="0x23" value="0x0023"/>  <!-- # → #  -->
+        <item key="0x24" value="0x0024"/>  <!-- $ → $  -->
+        <item key="0x25" value="0x0025"/>  <!-- % → %  -->
+        <item key="0x26" value="0x0026"/>  <!-- & → &  -->
+        <item key="0x27" value="0x0027"/>  <!-- ' → '  -->
+        <item key="0x28" value="0x0028"/>  <!-- ( → (  -->
+        <item key="0x29" value="0x0029"/>  <!-- ) → )  -->
+        <item key="0x2a" value="0x002a"/>  <!-- * → *  -->
+        <item key="0x2b" value="0x002b"/>  <!-- + → +  -->
+        <item key="0x2c" value="0x002c"/>  <!-- , → ,  -->
+        <item key="0x2d" value="0x002d"/>  <!-- - → -  -->
+        <item key="0x2e" value="0x002e"/>  <!-- . → .  -->
+        <item key="0x2f" value="0x002f"/>  <!-- / → /  -->
+        <item key="0x30" value="0x0030"/>  <!-- 0 → 0  -->
+        <item key="0x31" value="0x0031"/>  <!-- 1 → 1  -->
+        <item key="0x32" value="0x0032"/>  <!-- 2 → 2  -->
+        <item key="0x33" value="0x0033"/>  <!-- 3 → 3  -->
+        <item key="0x34" value="0x0034"/>  <!-- 4 → 4  -->
+        <item key="0x35" value="0x0035"/>  <!-- 5 → 5  -->
+        <item key="0x36" value="0x0036"/>  <!-- 6 → 6  -->
+        <item key="0x37" value="0x0037"/>  <!-- 7 → 7  -->
+        <item key="0x38" value="0x0038"/>  <!-- 8 → 8  -->
+        <item key="0x39" value="0x0039"/>  <!-- 9 → 9  -->
+        <item key="0x3a" value="0x003a"/>  <!-- : → :  -->
+        <item key="0x3b" value="0x003b"/>  <!-- ; → ;  -->
+        <item key="0x3c" value="0x003c"/>  <!-- < → <  -->
+        <item key="0x3d" value="0x003d"/>  <!-- = → =  -->
+        <item key="0x3e" value="0x003e"/>  <!-- > → >  -->
+        <item key="0x3f" value="0x003f"/>  <!-- ? → ?  -->
+        <item key="0x40" value="0x0040"/>  <!-- @ → @  -->
+        <item key="0x41" value="0x1106"/>  <!-- A → ᄆᅠ -->
+        <item key="0x42" value="0x1172"/>  <!-- B → ᅟᅲ -->
+        <item key="0x43" value="0x110e"/>  <!-- C → ᄎᅠ -->
+        <item key="0x44" value="0x110b"/>  <!-- D → ᄋᅠ -->
+        <item key="0x45" value="0x1104"/>  <!-- E → ᄄᅠ -->
+        <item key="0x46" value="0x1105"/>  <!-- F → ᄅᅠ -->
+        <item key="0x47" value="0x1112"/>  <!-- G → ᄒᅠ -->
+        <item key="0x48" value="0x1169"/>  <!-- H → ᅟᅩ -->
+        <item key="0x49" value="0x1163"/>  <!-- I → ᅟᅣ -->
+        <item key="0x4a" value="0x1165"/>  <!-- J → ᅟᅥ -->
+        <item key="0x4b" value="0x1161"/>  <!-- K → ᅟᅡ -->
+        <item key="0x4c" value="0x1175"/>  <!-- L → ᅟᅵ -->
+        <item key="0x4d" value="0x1173"/>  <!-- M → ᅟᅳ -->
+        <item key="0x4e" value="0x116e"/>  <!-- N → ᅟᅮ -->
+        <item key="0x4f" value="0x1164"/>  <!-- O → ᅟᅤ -->
+        <item key="0x50" value="0x1168"/>  <!-- P → ᅟᅨ -->
+        <item key="0x51" value="0x1108"/>  <!-- Q → ᄈᅠ -->
+        <item key="0x52" value="0x1101"/>  <!-- R → ᄁᅠ -->
+        <item key="0x53" value="0x1102"/>  <!-- S → ᄂᅠ -->
+        <item key="0x54" value="0x110a"/>  <!-- T → ᄊᅠ -->
+        <item key="0x55" value="0x1167"/>  <!-- U → ᅟᅧ -->
+        <item key="0x56" value="0x1111"/>  <!-- V → ᄑᅠ -->
+        <item key="0x57" value="0x110d"/>  <!-- W → ᄍᅠ -->
+        <item key="0x58" value="0x1110"/>  <!-- X → ᄐᅠ -->
+        <item key="0x59" value="0x116d"/>  <!-- Y → ᅟᅭ -->
+        <item key="0x5a" value="0x110f"/>  <!-- Z → ᄏᅠ -->
+        <item key="0x5b" value="0x005b"/>  <!-- [ → [  -->
+        <item key="0x5c" value="0x005c"/>  <!-- \ → \  -->
+        <item key="0x5d" value="0x005d"/>  <!-- ] → ]  -->
+        <item key="0x5e" value="0x005e"/>  <!-- ^ → ^  -->
+        <item key="0x5f" value="0x005f"/>  <!-- _ → _  -->
+        <item key="0x60" value="0x0060"/>  <!-- ` → `  -->
+        <item key="0x61" value="0x1106"/>  <!-- a → ᄆᅠ -->
+        <item key="0x62" value="0x1172"/>  <!-- b → ᅟᅲ -->
+        <item key="0x63" value="0x110e"/>  <!-- c → ᄎᅠ -->
+        <item key="0x64" value="0x110b"/>  <!-- d → ᄋᅠ -->
+        <item key="0x65" value="0x1103"/>  <!-- e → ᄃᅠ -->
+        <item key="0x66" value="0x1105"/>  <!-- f → ᄅᅠ -->
+        <item key="0x67" value="0x1112"/>  <!-- g → ᄒᅠ -->
+        <item key="0x68" value="0x1169"/>  <!-- h → ᅟᅩ -->
+        <item key="0x69" value="0x1163"/>  <!-- i → ᅟᅣ -->
+        <item key="0x6a" value="0x1165"/>  <!-- j → ᅟᅥ -->
+        <item key="0x6b" value="0x1161"/>  <!-- k → ᅟᅡ -->
+        <item key="0x6c" value="0x1175"/>  <!-- l → ᅟᅵ -->
+        <item key="0x6d" value="0x1173"/>  <!-- m → ᅟᅳ -->
+        <item key="0x6e" value="0x116e"/>  <!-- n → ᅟᅮ -->
+        <item key="0x6f" value="0x1162"/>  <!-- o → ᅟᅢ -->
+        <item key="0x70" value="0x1166"/>  <!-- p → ᅟᅦ -->
+        <item key="0x71" value="0x1107"/>  <!-- q → ᄇᅠ -->
+        <item key="0x72" value="0x1100"/>  <!-- r → ᄀᅠ -->
+        <item key="0x73" value="0x1102"/>  <!-- s → ᄂᅠ -->
+        <item key="0x74" value="0x1109"/>  <!-- t → ᄉᅠ -->
+        <item key="0x75" value="0x1167"/>  <!-- u → ᅟᅧ -->
+        <item key="0x76" value="0x1111"/>  <!-- v → ᄑᅠ -->
+        <item key="0x77" value="0x110c"/>  <!-- w → ᄌᅠ -->
+        <item key="0x78" value="0x1110"/>  <!-- x → ᄐᅠ -->
+        <item key="0x79" value="0x116d"/>  <!-- y → ᅟᅭ -->
+        <item key="0x7a" value="0x110f"/>  <!-- z → ᄏᅠ -->
+        <item key="0x7b" value="0x007b"/>  <!-- { → {  -->
+        <item key="0x7c" value="0x007c"/>  <!-- | → |  -->
+        <item key="0x7d" value="0x007d"/>  <!-- } → }  -->
+        <item key="0x7e" value="0x007e"/>  <!-- ~ → ~  -->
+    </map>
+
+    <include file="hangul-combination-default.xml"/>
+
+</hangul-keyboard>

--- a/data/keyboards/hangul-keyboard-2y-full.xml.template
+++ b/data/keyboards/hangul-keyboard-2y-full.xml.template
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hangul-keyboard id="2y-full" type="jamo-yet">
+
+    <_name>Dubeolsik Yetgeul</_name>
+
+    <map id="0">
+        <item key="0x21" value="0x0021"/>  <!-- ! → !  -->
+        <item key="0x22" value="0x0022"/>  <!-- " → "  -->
+        <item key="0x23" value="0x0023"/>  <!-- # → #  -->
+        <item key="0x24" value="0x0024"/>  <!-- $ → $  -->
+        <item key="0x25" value="0x0025"/>  <!-- % → %  -->
+        <item key="0x26" value="0x0026"/>  <!-- & → &  -->
+        <item key="0x27" value="0x0027"/>  <!-- ' → '  -->
+        <item key="0x28" value="0x0028"/>  <!-- ( → (  -->
+        <item key="0x29" value="0x0029"/>  <!-- ) → )  -->
+        <item key="0x2a" value="0x002a"/>  <!-- * → *  -->
+        <item key="0x2b" value="0x002b"/>  <!-- + → +  -->
+        <item key="0x2c" value="0x002c"/>  <!-- , → ,  -->
+        <item key="0x2d" value="0x002d"/>  <!-- - → -  -->
+        <item key="0x2e" value="0x002e"/>  <!-- . → .  -->
+        <item key="0x2f" value="0x002f"/>  <!-- / → /  -->
+        <item key="0x30" value="0x0030"/>  <!-- 0 → 0  -->
+        <item key="0x31" value="0x0031"/>  <!-- 1 → 1  -->
+        <item key="0x32" value="0x0032"/>  <!-- 2 → 2  -->
+        <item key="0x33" value="0x0033"/>  <!-- 3 → 3  -->
+        <item key="0x34" value="0x0034"/>  <!-- 4 → 4  -->
+        <item key="0x35" value="0x0035"/>  <!-- 5 → 5  -->
+        <item key="0x36" value="0x0036"/>  <!-- 6 → 6  -->
+        <item key="0x37" value="0x0037"/>  <!-- 7 → 7  -->
+        <item key="0x38" value="0x0038"/>  <!-- 8 → 8  -->
+        <item key="0x39" value="0x0039"/>  <!-- 9 → 9  -->
+        <item key="0x3a" value="0x003a"/>  <!-- : → :  -->
+        <item key="0x3b" value="0x003b"/>  <!-- ; → ;  -->
+        <item key="0x3c" value="0x003c"/>  <!-- < → <  -->
+        <item key="0x3d" value="0x003d"/>  <!-- = → =  -->
+        <item key="0x3e" value="0x003e"/>  <!-- > → >  -->
+        <item key="0x3f" value="0x003f"/>  <!-- ? → ?  -->
+        <item key="0x40" value="0x0040"/>  <!-- @ → @  -->
+        <item key="0x41" value="0x1140"/>  <!-- A → ᅀᅠ -->
+        <item key="0x42" value="0x1154"/>  <!-- B → ᅔᅠ -->
+        <item key="0x43" value="0x114e"/>  <!-- C → ᅎᅠ -->
+        <item key="0x44" value="0x114c"/>  <!-- D → ᅌᅠ -->
+        <item key="0x45" value="0x1104"/>  <!-- E → ᄄᅠ -->
+        <item key="0x46" value="0x111a"/>  <!-- F → ᄚᅠ -->
+        <item key="0x47" value="0x1159"/>  <!-- G → ᅙᅠ -->
+        <item key="0x48" value="0x1183"/>  <!-- H → ᅟᆃ -->
+        <item key="0x49" value="0x1163"/>  <!-- I → ᅟᅣ -->
+        <item key="0x4a" value="0x1165"/>  <!-- J → ᅟᅥ -->
+        <item key="0x4b" value="0x119e"/>  <!-- K → ᅟᆞ -->
+        <item key="0x4c" value="0x1194"/>  <!-- L → ᅟᆔ -->
+        <item key="0x4d" value="0x1173"/>  <!-- M → ᅟᅳ -->
+        <item key="0x4e" value="0x1155"/>  <!-- N → ᅕᅠ -->
+        <item key="0x4f" value="0x1164"/>  <!-- O → ᅟᅤ -->
+        <item key="0x50" value="0x1168"/>  <!-- P → ᅟᅨ -->
+        <item key="0x51" value="0x1108"/>  <!-- Q → ᄈᅠ -->
+        <item key="0x52" value="0x1101"/>  <!-- R → ᄁᅠ -->
+        <item key="0x53" value="0x115d"/>  <!-- S → ᅝᅠ -->
+        <item key="0x54" value="0x110a"/>  <!-- T → ᄊᅠ -->
+        <item key="0x55" value="0x1167"/>  <!-- U → ᅟᅧ -->
+        <item key="0x56" value="0x1150"/>  <!-- V → ᅐᅠ -->
+        <item key="0x57" value="0x110d"/>  <!-- W → ᄍᅠ -->
+        <item key="0x58" value="0x113e"/>  <!-- X → ᄾᅠ -->
+        <item key="0x59" value="0x116d"/>  <!-- Y → ᅟᅭ -->
+        <item key="0x5a" value="0x113c"/>  <!-- Z → ᄼᅠ -->
+        <item key="0x5b" value="0x005b"/>  <!-- [ → [  -->
+        <item key="0x5c" value="0x005c"/>  <!-- \ → \  -->
+        <item key="0x5d" value="0x005d"/>  <!-- ] → ]  -->
+        <item key="0x5e" value="0x005e"/>  <!-- ^ → ^  -->
+        <item key="0x5f" value="0x005f"/>  <!-- _ → _  -->
+        <item key="0x60" value="0x0060"/>  <!-- ` → `  -->
+        <item key="0x61" value="0x1106"/>  <!-- a → ᄆᅠ -->
+        <item key="0x62" value="0x1172"/>  <!-- b → ᅟᅲ -->
+        <item key="0x63" value="0x110e"/>  <!-- c → ᄎᅠ -->
+        <item key="0x64" value="0x110b"/>  <!-- d → ᄋᅠ -->
+        <item key="0x65" value="0x1103"/>  <!-- e → ᄃᅠ -->
+        <item key="0x66" value="0x1105"/>  <!-- f → ᄅᅠ -->
+        <item key="0x67" value="0x1112"/>  <!-- g → ᄒᅠ -->
+        <item key="0x68" value="0x1169"/>  <!-- h → ᅟᅩ -->
+        <item key="0x69" value="0x1163"/>  <!-- i → ᅟᅣ -->
+        <item key="0x6a" value="0x1165"/>  <!-- j → ᅟᅥ -->
+        <item key="0x6b" value="0x1161"/>  <!-- k → ᅟᅡ -->
+        <item key="0x6c" value="0x1175"/>  <!-- l → ᅟᅵ -->
+        <item key="0x6d" value="0x1173"/>  <!-- m → ᅟᅳ -->
+        <item key="0x6e" value="0x116e"/>  <!-- n → ᅟᅮ -->
+        <item key="0x6f" value="0x1162"/>  <!-- o → ᅟᅢ -->
+        <item key="0x70" value="0x1166"/>  <!-- p → ᅟᅦ -->
+        <item key="0x71" value="0x1107"/>  <!-- q → ᄇᅠ -->
+        <item key="0x72" value="0x1100"/>  <!-- r → ᄀᅠ -->
+        <item key="0x73" value="0x1102"/>  <!-- s → ᄂᅠ -->
+        <item key="0x74" value="0x1109"/>  <!-- t → ᄉᅠ -->
+        <item key="0x75" value="0x1167"/>  <!-- u → ᅟᅧ -->
+        <item key="0x76" value="0x1111"/>  <!-- v → ᄑᅠ -->
+        <item key="0x77" value="0x110c"/>  <!-- w → ᄌᅠ -->
+        <item key="0x78" value="0x1110"/>  <!-- x → ᄐᅠ -->
+        <item key="0x79" value="0x116d"/>  <!-- y → ᅟᅭ -->
+        <item key="0x7a" value="0x110f"/>  <!-- z → ᄏᅠ -->
+        <item key="0x7b" value="0x007b"/>  <!-- { → {  -->
+        <item key="0x7c" value="0x007c"/>  <!-- | → |  -->
+        <item key="0x7d" value="0x007d"/>  <!-- } → }  -->
+        <item key="0x7e" value="0x007e"/>  <!-- ~ → ~  -->
+    </map>
+
+    <include file="hangul-combination-full.xml"/>
+
+</hangul-keyboard>


### PR DESCRIPTION
2.xml.template과 2y.xml.template은 본래 libhangul에서 작성한 것 같아 수정하지 않고 추가 파일로 만들었습니다.
제가 영문 자판으로 [Workman](https://workmanlayout.org) 레이아웃을 사용하는데요, 이 자판은 <kbd>;</kbd> 위치에 `i`를, <kbd>p</kbd> 위치에 `;`를 사용합니다.

구름 입력기 두벌식 자판과 Workman 자판만을 추가해 사용하면, 구름 입력기에서 처리되지 않는 입력은 Workman 자판으로 들어가는데, 그에 따라 두벌식 자판에서 <kbd>;</kbd>를 누르면 `i`가 입력되어 실제로 `;`나 `:`를 입력할 수 없게 됩니다. 그래서 두벌식 자판과 두벌식 옛글 자판 map에서 빠진 item을 모두 추가한 템플릿을 추가합니다.

현재 구름 입력기에 추가된 자판은 두벌식, 두벌식 옛글 자판을 제외하면 모두 0x21부터 0x7e까지 map에 추가되어 있습니다.