### PR TITLE
최종 순아래 특수문자 처리 개선 (/, ')

### DIFF
--- a/hangul/hangul.h
+++ b/hangul/hangul.h
@@ -106,7 +106,7 @@ HangulKeyboard* hangul_keyboard_new_from_file(const char* path);
 void    hangul_keyboard_delete(HangulKeyboard *keyboard);
 void    hangul_keyboard_set_type(HangulKeyboard *keyboard, int type);
 void    hangul_keyboard_set_mode_key(HangulKeyboard *keyboard, ucschar key);
-ucschar    hangul_keyboard_get_mode_key(HangulKeyboard *keyboard);
+ucschar    hangul_keyboard_get_mode_key(const HangulKeyboard *keyboard);
 
 unsigned int hangul_keyboard_list_get_count(void);
 const char* hangul_keyboard_list_get_keyboard_id(unsigned index_);

--- a/hangul/hangulinputcontext.c
+++ b/hangul/hangulinputcontext.c
@@ -912,6 +912,13 @@ static bool
 hangul_ic_process_gureum(HangulInputContext *hic, ucschar ch)
 {
     ucschar mode_key = hangul_keyboard_get_mode_key(hic->keyboard);
+    if (hic->buffer.choseong == 0) {
+        if (ch == 0x1171) {
+            ch = 0x27;
+        } else if (ch == 0x116c) {
+            ch = 0x2f;
+        }
+    }
 
     if (hangul_is_choseong(ch)) {
         if (hic->buffer.choseong == 0) {

--- a/hangul/hangulkeyboard.c
+++ b/hangul/hangulkeyboard.c
@@ -513,7 +513,7 @@ hangul_keyboard_set_mode_key(HangulKeyboard *keyboard, ucschar key)
 }
 
 ucschar
-hangul_keyboard_get_mode_key(HangulKeyboard *keyboard)
+hangul_keyboard_get_mode_key(const HangulKeyboard *keyboard)
 {
     return keyboard->mode_key;
 }


### PR DESCRIPTION
초성이 없을 때는 /와 '를, 있을 때는 조합용 ㅚ와 ㅟ를 입력합니다

cc @tobark

